### PR TITLE
festival-api 패키지 업데이트, group-chatRoom 패키지 업데이트, festival-comment 패키지 업데이트, NotProd 업데이트, 의존성 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,12 @@ dependencies {
 	runtimeOnly ("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly ("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+	// ApiScheduler: Xml -> Json
+	dependencies {
+		implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.2")
+		implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
+		implementation("com.fasterxml.jackson.core:jackson-annotations:2.18.2")
+	}
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,3 +64,23 @@ dependencies {
 tasks.withType<Test> {
 	useJUnitPlatform()
 }
+
+val querydslDir = "src/main/generated"
+
+sourceSets {
+	main {
+		java {
+			srcDir(querydslDir)
+		}
+	}
+}
+
+tasks.withType<JavaCompile> {
+	options.generatedSourceOutputDirectory.set(file(querydslDir))
+}
+
+tasks.named("clean") {
+	doLast {
+		file(querydslDir).deleteRecursively()
+	}
+}

--- a/src/main/java/com/ll/hfback/domain/festival/api/scheduler/FetchKopisScheduler.java
+++ b/src/main/java/com/ll/hfback/domain/festival/api/scheduler/FetchKopisScheduler.java
@@ -20,7 +20,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -59,7 +58,7 @@ public class FetchKopisScheduler {
                  * */
                 int rows = 100;
                 int currentPage = 1;
-                int maxPage = 5;
+                int maxPage = 15;
 
                 while (currentPage <= maxPage) {
 
@@ -68,12 +67,10 @@ public class FetchKopisScheduler {
                             serviceKeyForKopis, stdate, eddate, rows, currentPage
                     );
 
-
                     URL url = new URL(apiUrl);
                     HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                     connection.setRequestMethod("GET");
                     connection.setRequestProperty("Content-Type", "application/xml");
-
 
                     BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), "UTF-8"));
                     StringBuilder responseBuilder = new StringBuilder();

--- a/src/main/java/com/ll/hfback/domain/festival/api/service/ApiService.java
+++ b/src/main/java/com/ll/hfback/domain/festival/api/service/ApiService.java
@@ -4,7 +4,6 @@ import com.ll.hfback.domain.festival.post.entity.Post;
 
 import java.util.List;
 
-
 public interface ApiService {
     // Apis의 데이터를 Post에 저장
     void saveForApis(String jsonResponse);
@@ -14,7 +13,4 @@ public interface ApiService {
 
     // KOPIS에서 받아온 xml데이터를 Post객체로 변환
     List<Post> parseXmlToEntity(String xml) throws Exception;
-
-    // xml의 <db>태그와 매칭되는 데이터 추출 메서드
-    String getTagValue(String tag, org.w3c.dom.Element element);
 }

--- a/src/main/java/com/ll/hfback/domain/festival/comment/form/AddCommentForm.java
+++ b/src/main/java/com/ll/hfback/domain/festival/comment/form/AddCommentForm.java
@@ -1,6 +1,5 @@
 package com.ll.hfback.domain.festival.comment.form;
 
-import com.ll.hfback.domain.member.member.entity.Member;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -12,7 +11,6 @@ public class AddCommentForm {
     @NotEmpty
     @Size(max = 500)
     private String content;
-    private Member member;
     private Long superCommentId = null;
 }
 

--- a/src/main/java/com/ll/hfback/domain/festival/post/entity/Post.java
+++ b/src/main/java/com/ll/hfback/domain/festival/post/entity/Post.java
@@ -1,10 +1,10 @@
 package com.ll.hfback.domain.festival.post.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -15,23 +15,37 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @SuperBuilder
 @ToString(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Post {
     @Id
+    @JacksonXmlProperty(localName = "mt20id")
     private String festivalId;
 
+    @JacksonXmlProperty(localName = "prfnm")
     private String festivalName;
+
+    @JacksonXmlProperty(localName = "prfpdfrom")
     private String festivalStartDate;
+
+    @JacksonXmlProperty(localName = "prfpdto")
     private String festivalEndDate;
+
+    @JacksonXmlProperty(localName = "area")
     private String festivalArea;
+
+    @JacksonXmlProperty(localName = "fcltynm")
     private String festivalHallName;
+
+    @JacksonXmlProperty(localName = "prfstate")
     private String festivalState;
+
+    @JacksonXmlProperty(localName = "poster")
     private String festivalUrl;
-    private String inputType;
+
+    @JacksonXmlProperty(localName = "genrenm")
     private String genrenm;
 
-    @CreatedDate
     private LocalDateTime createDate;
-
-    @LastModifiedDate
     private LocalDateTime modifyDate;
+    private String inputType;
 }

--- a/src/main/java/com/ll/hfback/domain/group/chatRoom/auth/AuService.java
+++ b/src/main/java/com/ll/hfback/domain/group/chatRoom/auth/AuService.java
@@ -1,0 +1,51 @@
+package com.ll.hfback.domain.group.chatRoom.auth;
+
+import com.ll.hfback.domain.member.member.entity.Member;
+import com.ll.hfback.domain.member.member.repository.MemberRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuService {
+    private final MemberRepository memberRepository;
+
+    public AuService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    // 이메일로 member 조회 및 반환
+    public Member getMemberByEmail(String email) {
+        Member member = memberRepository.findByEmail(email);
+        if (member == null) {
+            throw new IllegalStateException("사용자를 찾을 수 없습니다.");
+        }
+        return member;
+    }
+
+    // 현재 로그인한 사용자의 고유 ID를 가져오는 메서드
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("인증되지 않은 사용자입니다.");
+        }
+
+        // getName()에서 이메일을 가져온 후, MemberRepository를 통해 사용자 조회
+        String email = authentication.getName(); // 사용자 이메일
+        Member member = getMemberByEmail(email); // 이메일로 사용자 조회
+        return member.getId(); // 사용자의 고유 ID 반환
+    }
+
+    // 현재 로그인한 사용자의 member 객체를 가져오는 메서드
+    public Member getCurrentMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("인증되지 않은 사용자입니다.");
+        }
+
+        // getName()에서 이메일을 가져온 후, MemberRepository를 통해 사용자 조회
+        String email = authentication.getName(); // 사용자 이메일
+        Member member = getMemberByEmail(email); // 이메일로 사용자 조회
+        return member; // 사용자의 member 객체 반환
+    }
+}

--- a/src/main/java/com/ll/hfback/domain/group/chatRoom/controller/ChatRoomController.java
+++ b/src/main/java/com/ll/hfback/domain/group/chatRoom/controller/ChatRoomController.java
@@ -5,7 +5,6 @@ import com.ll.hfback.domain.group.chatRoom.dto.DetailChatRoomDto;
 import com.ll.hfback.domain.group.chatRoom.form.CreateChatRoomForm;
 import com.ll.hfback.domain.group.chatRoom.form.UpdateChatRoomForm;
 import com.ll.hfback.domain.group.chatRoom.service.ChatRoomService;
-import com.ll.hfback.domain.member.member.entity.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,10 +26,10 @@ public class ChatRoomController {
         return chatRoomService.searchByFestivalId(festivalId);
     }
 
-    // 해당 게시글의 모임채팅방 상세 조회
-    @GetMapping("/chat-room/{chat-room-id}/{member-id}")
-    public Optional<DetailChatRoomDto> getRoom(@PathVariable("chat-room-id") Long chatRoomId, @PathVariable("member-id") String memberId) {
-        return chatRoomService.searchById(chatRoomId, memberId);
+    // 해당 게시글의 모임채팅방 상세 조회(참여자 명단에 있는 사용자만 접근 가능)
+    @GetMapping("/chat-room/{chat-room-id}")
+    public Optional<DetailChatRoomDto> getRoom(@PathVariable("chat-room-id") Long chatRoomId) {
+        return chatRoomService.searchById(chatRoomId);
     }
 
     // 해당 게시글에 모임채팅방 생성
@@ -40,14 +39,14 @@ public class ChatRoomController {
         return ResponseEntity.status(HttpStatus.CREATED).body("모임이 성공적으로 만들어졌습니다.");
     }
 
-    // 해당 모임채팅방 수정
+    // 해당 모임채팅방 수정(방장만 가능)
     @PostMapping("/update-chat-room/{chat-room-id}")
     public ResponseEntity<String> updateRoom(@PathVariable("chat-room-id") Long chatRoomId, @RequestBody @Valid UpdateChatRoomForm updateChatRoomForm) {
         chatRoomService.updateChatRoom(chatRoomId, updateChatRoomForm);
         return ResponseEntity.status(HttpStatus.CREATED).body("모임이 성공적으로 수정되었습니다.");
     }
 
-    // 해당 모임채팅방 삭제
+    // 해당 모임채팅방 삭제(방장만 가능)
     @GetMapping("/delete-chat-room/{chat-room-id}")
     public ResponseEntity<String> deleteRoom(@PathVariable("chat-room-id") Long chatRoomId) {
         chatRoomService.deleteChatRoom(chatRoomId);
@@ -55,9 +54,9 @@ public class ChatRoomController {
     }
 
     // 해당 모임채팅방에 참여신청
-    @GetMapping("/apply-chat-room/{chat-room-id}/{member-id}")
-    public ResponseEntity<String> applyChatRoom(@PathVariable("chat-room-id") Long chatRoomId, @PathVariable("member-id") String memberId) {
-        chatRoomService.applyChatRoom(chatRoomId, memberId);
+    @GetMapping("/apply-chat-room/{chat-room-id}")
+    public ResponseEntity<String> applyChatRoom(@PathVariable("chat-room-id") Long chatRoomId) {
+        chatRoomService.applyChatRoom(chatRoomId);
         return ResponseEntity.status(HttpStatus.CREATED).body("성공적으로 모임에 참여 신청을 했습니다.");
     }
 

--- a/src/main/java/com/ll/hfback/domain/group/chatRoom/dto/DetailChatRoomDto.java
+++ b/src/main/java/com/ll/hfback/domain/group/chatRoom/dto/DetailChatRoomDto.java
@@ -18,7 +18,9 @@ public class DetailChatRoomDto {
     private String roomTitle;
     private String roomContent;
     @Convert(converter = StringListConverter.class)
-    private List<String> joinMemberList;
+    private List<String> joinMemberNicknames;
+    @Convert(converter = StringListConverter.class)
+    private List<String> waitingMemberNicknames;
     private Long roomMemberLimit;
     private int joinMemberNum;
 }

--- a/src/main/java/com/ll/hfback/domain/group/chatRoom/form/CreateChatRoomForm.java
+++ b/src/main/java/com/ll/hfback/domain/group/chatRoom/form/CreateChatRoomForm.java
@@ -1,6 +1,5 @@
 package com.ll.hfback.domain.group.chatRoom.form;
 
-import com.ll.hfback.domain.member.member.entity.Member;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -15,6 +14,5 @@ public class CreateChatRoomForm {
     @NotEmpty
     @Size(max = 500)
     private String roomContent;
-    private Member member;
     private Long roomMemberLimit; // 최소 10명 ~ 최대 100명 (스크롤 형식)
 }

--- a/src/main/java/com/ll/hfback/domain/group/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/com/ll/hfback/domain/group/chatRoom/service/ChatRoomService.java
@@ -17,7 +17,7 @@ public interface ChatRoomService {
     List<ChatRoomDto> searchByFestivalId(String festivalId);
 
     // 해당 게시글의 모임 상세 조회
-    Optional<DetailChatRoomDto> searchById(Long id, String memberId);
+    Optional<DetailChatRoomDto> searchById(Long id);
 
     // DB에서 받아온 참여자명단과 대기자명단을 List<String>으로 변환하고, ChatRoom을 ChatRoomDto로 변환하는 메서드
     ChatRoomDto convertToChatRoomDto(ChatRoom chatRoom);
@@ -35,5 +35,5 @@ public interface ChatRoomService {
     void deleteChatRoom(Long chatRoomId);
 
     // 해당 모임채팅방에 참여신청
-    void applyChatRoom(Long chatRoomId, String memberId);
+    void applyChatRoom(Long chatRoomId);
 }

--- a/src/main/java/com/ll/hfback/global/initData/NotProd.java
+++ b/src/main/java/com/ll/hfback/global/initData/NotProd.java
@@ -55,32 +55,32 @@ public class NotProd {
                 //
                 //
                 // member1이 PF256158 공연게시글에 작성한 테스트 댓글
-                AddCommentForm addCommentForm1 = new AddCommentForm();
-                addCommentForm1.setContent("이것은 member1이 작성한 테스트 댓글입니다.");
-                addCommentForm1.setMember(member1);
-                addCommentForm1.setSuperCommentId(null);
-                commentService.addComment("PF256158", addCommentForm1);
+                // member1 로그인 로직 필요
+//                AddCommentForm addCommentForm1 = new AddCommentForm();
+//                addCommentForm1.setContent("이것은 member1이 작성한 테스트 댓글입니다.");
+//                addCommentForm1.setSuperCommentId(null);
+//                commentService.addComment("PF256158", addCommentForm1);
 
                 // member2가 PF256158 공연게시글에 작성한 테스트 댓글
-                AddCommentForm addCommentForm2 = new AddCommentForm();
-                addCommentForm2.setContent("이것은 member2가 작성한 테스트 댓글입니다.");
-                addCommentForm2.setMember(member2);
-                addCommentForm2.setSuperCommentId(null);
-                commentService.addComment("PF256158", addCommentForm2);
+                // member2 로그인 로직 필요
+//                AddCommentForm addCommentForm2 = new AddCommentForm();
+//                addCommentForm2.setContent("이것은 member2가 작성한 테스트 댓글입니다.");
+//                addCommentForm2.setSuperCommentId(null);
+//                commentService.addComment("PF256158", addCommentForm2);
 
                 // member3가 PF256158 공연게시글에서 memeber1의 댓글에 작성한 테스트 답글
-                AddCommentForm addCommentForm3 = new AddCommentForm();
-                addCommentForm3.setContent("이것은 member3이 작성한 테스트 답글입니다.");
-                addCommentForm3.setMember(member3);
-                addCommentForm3.setSuperCommentId(1L);
-                commentService.addComment("PF256158", addCommentForm3);
+                // member3 로그인 로직 필요
+//                AddCommentForm addCommentForm3 = new AddCommentForm();
+//                addCommentForm3.setContent("이것은 member3이 작성한 테스트 답글입니다.");
+//                addCommentForm3.setSuperCommentId(1L);
+//                commentService.addComment("PF256158", addCommentForm3);
 
                 // member3가 PF256158 공연게시글에서 memeber2의 댓글에 작성한 테스트 답글
-                AddCommentForm addCommentForm4 = new AddCommentForm();
-                addCommentForm4.setContent("이것은 member3이 작성한 테스트 답글입니다.");
-                addCommentForm4.setMember(member3);
-                addCommentForm4.setSuperCommentId(2L);
-                commentService.addComment("PF256158", addCommentForm4);
+                // member3 로그인 로직 필요
+//                AddCommentForm addCommentForm4 = new AddCommentForm();
+//                addCommentForm4.setContent("이것은 member3이 작성한 테스트 답글입니다.");
+//                addCommentForm4.setSuperCommentId(2L);
+//                commentService.addComment("PF256158", addCommentForm4);
 
 
 
@@ -88,9 +88,10 @@ public class NotProd {
                 //
                 //
                 // member1이 수정한 테스트 댓글(comment-id=1)
-                UpdateCommentForm updateCommentForm = new UpdateCommentForm();
-                updateCommentForm.setContent("이것은 member1이 다시 수정한 테스트 댓글입니다.");
-                commentService.updateComment(1L, updateCommentForm);
+                // member1 로그인 로직 필요
+//                UpdateCommentForm updateCommentForm = new UpdateCommentForm();
+//                updateCommentForm.setContent("이것은 member1이 다시 수정한 테스트 댓글입니다.");
+//                commentService.updateComment(1L, updateCommentForm);
                 
 
                 
@@ -98,28 +99,28 @@ public class NotProd {
                 //
                 //
                 // member1이 PF256158 공연게시글에서 만든 모임채팅방
-                CreateChatRoomForm createChatRoomForm1 = new CreateChatRoomForm();
-                createChatRoomForm1.setMember(member1);
-                createChatRoomForm1.setRoomTitle("이것은 member1이 작성한 테스트 제목입니다.");
-                createChatRoomForm1.setRoomContent("이것은 member1이 작성한 테스트 본문입니다.");
-                createChatRoomForm1.setRoomMemberLimit(10L);
-                chatroomservice.createChatRoom("PF256158", createChatRoomForm1);
+                // member1 로그인 로직 필요
+//                CreateChatRoomForm createChatRoomForm1 = new CreateChatRoomForm();
+//                createChatRoomForm1.setRoomTitle("이것은 member1이 작성한 테스트 제목입니다.");
+//                createChatRoomForm1.setRoomContent("이것은 member1이 작성한 테스트 본문입니다.");
+//                createChatRoomForm1.setRoomMemberLimit(10L);
+//                chatroomservice.createChatRoom("PF256158", createChatRoomForm1);
 
                 // member2가 PF256158 공연게시글에서 만든 모임채팅방
-                CreateChatRoomForm createChatRoomForm2 = new CreateChatRoomForm();
-                createChatRoomForm2.setMember(member2);
-                createChatRoomForm2.setRoomTitle("이것은 member2가 작성한 테스트 제목입니다.");
-                createChatRoomForm2.setRoomContent("이것은 member2가 작성한 테스트 본문입니다.");
-                createChatRoomForm2.setRoomMemberLimit(20L);
-                chatroomservice.createChatRoom("PF256158", createChatRoomForm2);
+                // member2 로그인 로직 필요
+//                CreateChatRoomForm createChatRoomForm2 = new CreateChatRoomForm();
+//                createChatRoomForm2.setRoomTitle("이것은 member2가 작성한 테스트 제목입니다.");
+//                createChatRoomForm2.setRoomContent("이것은 member2가 작성한 테스트 본문입니다.");
+//                createChatRoomForm2.setRoomMemberLimit(20L);
+//                chatroomservice.createChatRoom("PF256158", createChatRoomForm2);
 
                 // member3가 PF256158 공연게시글에서 만든 모임채팅방
-                CreateChatRoomForm createChatRoomForm3 = new CreateChatRoomForm();
-                createChatRoomForm3.setMember(member3);
-                createChatRoomForm3.setRoomTitle("이것은 member3이 작성한 테스트 제목입니다.");
-                createChatRoomForm3.setRoomContent("이것은 member3이 작성한 테스트 본문입니다.");
-                createChatRoomForm3.setRoomMemberLimit(30L);
-                chatroomservice.createChatRoom("PF256158", createChatRoomForm3);
+                // member3 로그인 로직 필요
+//                CreateChatRoomForm createChatRoomForm3 = new CreateChatRoomForm();
+//                createChatRoomForm3.setRoomTitle("이것은 member3이 작성한 테스트 제목입니다.");
+//                createChatRoomForm3.setRoomContent("이것은 member3이 작성한 테스트 본문입니다.");
+//                createChatRoomForm3.setRoomMemberLimit(30L);
+//                chatroomservice.createChatRoom("PF256158", createChatRoomForm3);
 
 
 
@@ -127,11 +128,32 @@ public class NotProd {
                 //
                 //
                 // member1이 수정한 테스트 모임채팅방(chat-room-id=1)
-                UpdateChatRoomForm updateChatRoomForm = new UpdateChatRoomForm();
-                updateChatRoomForm.setRoomTitle("이것은 member1이 다시 수정한 테스트 제목입니다.");
-                updateChatRoomForm.setRoomContent("이것은 member1이 다시 수정한 테스트 본문입니다.");
-                updateChatRoomForm.setRoomMemberLimit(100L);
-                chatroomservice.updateChatRoom(1L, updateChatRoomForm);
+                // member1 로그인 로직 필요
+//                UpdateChatRoomForm updateChatRoomForm = new UpdateChatRoomForm();
+//                updateChatRoomForm.setRoomTitle("이것은 member1이 다시 수정한 테스트 제목입니다.");
+//                updateChatRoomForm.setRoomContent("이것은 member1이 다시 수정한 테스트 본문입니다.");
+//                updateChatRoomForm.setRoomMemberLimit(100L);
+//                chatroomservice.updateChatRoom(1L, updateChatRoomForm);
+
+
+
+                // 테스트 모임채팅방 참여신청
+                //
+                //
+                // member1이 chat-room-id=2,3에 참여신청
+                // member1 로그인 로직 필요
+//                chatroomservice.applyChatRoom(2L);
+//                chatroomservice.applyChatRoom(3L);
+
+                // member2가 chat-room-id=1,3에 참여신청
+                // member2 로그인 로직 필요
+//                chatroomservice.applyChatRoom(1L);
+//                chatroomservice.applyChatRoom(3L);
+
+                // member3이 chat-room-id=1,2에 참여신청
+                // member3 로그인 로직 필요
+//                chatroomservice.applyChatRoom(1L);
+//                chatroomservice.applyChatRoom(2L);
             }
         };
     }


### PR DESCRIPTION
festival-api 패키지 업데이트
- Apis 스케쥴러 호출시 발생하는 에러 해결(Json 응답 메시지 첫줄이 xml 코드였음)
- 기존 Kopis 스케쥴러의 xml->json 형식 수작업 변환을 jackson라이브러리 도입으로 간결화

group-chatRoom 패키지 업데이트
- 모임채팅방 상세 조회(참여자만 가능)
- 모임채팅방 수정/삭제(방장만 가능)
- 임시 패키지 auth 도입(AuService)
검토 후 member.auth.service.AuthService에 통합 필요

festival-comment 패키지 업데이트
- 댓글 수정/삭제(작성자만 가능)

NotProd 업데이트
- Comment, chatRoom 테스트 데이터 주석 처리
- 로그인 서비스 구현 필요

build.gradle.kts에 jackson 의존성 추가