### PR TITLE
feat: 메시지 읽음 상태 확인을 위한 기능 추가

### DIFF
--- a/src/main/generated/com/ll/hfback/domain/group/chat/entity/QChatMessage.java
+++ b/src/main/generated/com/ll/hfback/domain/group/chat/entity/QChatMessage.java
@@ -26,8 +26,6 @@ public class QChatMessage extends EntityPathBase<ChatMessage> {
 
     public final StringPath chatMessageContent = createString("chatMessageContent");
 
-    public final NumberPath<Integer> chatMessageStatus = createNumber("chatMessageStatus", Integer.class);
-
     public final com.ll.hfback.domain.group.chatRoom.entity.QChatRoom chatRoom;
 
     //inherited

--- a/src/main/generated/com/ll/hfback/domain/group/chat/entity/QMessageReadStatus.java
+++ b/src/main/generated/com/ll/hfback/domain/group/chat/entity/QMessageReadStatus.java
@@ -1,0 +1,62 @@
+package com.ll.hfback.domain.group.chat.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMessageReadStatus is a Querydsl query type for MessageReadStatus
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMessageReadStatus extends EntityPathBase<MessageReadStatus> {
+
+    private static final long serialVersionUID = 1766137257L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMessageReadStatus messageReadStatus = new QMessageReadStatus("messageReadStatus");
+
+    public final com.ll.hfback.global.jpa.QBaseEntity _super = new com.ll.hfback.global.jpa.QBaseEntity(this);
+
+    public final com.ll.hfback.domain.group.chatRoom.entity.QChatRoom chatRoom;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final NumberPath<Long> lastReadMessageId = createNumber("lastReadMessageId", Long.class);
+
+    public final com.ll.hfback.domain.member.member.entity.QMember member;
+
+    public QMessageReadStatus(String variable) {
+        this(MessageReadStatus.class, forVariable(variable), INITS);
+    }
+
+    public QMessageReadStatus(Path<? extends MessageReadStatus> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMessageReadStatus(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMessageReadStatus(PathMetadata metadata, PathInits inits) {
+        this(MessageReadStatus.class, metadata, inits);
+    }
+
+    public QMessageReadStatus(Class<? extends MessageReadStatus> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.chatRoom = inits.isInitialized("chatRoom") ? new com.ll.hfback.domain.group.chatRoom.entity.QChatRoom(forProperty("chatRoom"), inits.get("chatRoom")) : null;
+        this.member = inits.isInitialized("member") ? new com.ll.hfback.domain.member.member.entity.QMember(forProperty("member")) : null;
+    }
+
+}
+

--- a/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
@@ -5,6 +5,7 @@ import com.ll.hfback.domain.group.chat.request.MessageReadStatusRequest;
 import com.ll.hfback.domain.group.chat.request.MessageSearchKeywordsRequest;
 import com.ll.hfback.domain.group.chat.request.RequestMessage;
 import com.ll.hfback.domain.group.chat.service.ChatMessageService;
+import com.ll.hfback.global.rsData.RsData;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
@@ -28,34 +29,49 @@ public class ApiV1ChatMessageController {
 
     // 채팅 메시지 작성
     @PostMapping("/messages")
-    public void writeMessage(@PathVariable("chatRoom-id") Long chatRoomId,
-                             @RequestBody RequestMessage requestMessage) {
-        chatMessageService.writeMessage(chatRoomId,
-                requestMessage);
+    public RsData<Void> writeMessage(@PathVariable("chatRoom-id") Long chatRoomId,
+                      @RequestBody RequestMessage requestMessage) {
+        try {
+            chatMessageService.writeMessage(chatRoomId, requestMessage);
+            return new RsData<>("200", "채팅 메시지 작성에 성공했습니다.");
+        } catch (Exception e) {
+            return new RsData<>("500", "채팅 메시지 작성 중 오류가 발생했습니다: " + e.getMessage());
+        }
     }
 
     // 채팅 메시지 조회
     @GetMapping("/messages")
-    public Page<ResponseMessage> readMessages(@PathVariable("chatRoom-id") Long chatRoomId,
-                                              @RequestParam(value = "page", defaultValue = "0") int page) {
-
-        return chatMessageService.readMessages(chatRoomId, page);
+    public RsData<Page<ResponseMessage>> readMessages(@PathVariable("chatRoom-id") Long chatRoomId,
+                                                @RequestParam(value = "page", defaultValue = "0") int page) {
+        try {
+            return new RsData<Page<ResponseMessage>>("200","채팅 메시지 조회가 성공했습니다.", chatMessageService.readMessages(chatRoomId, page));
+        } catch (Exception e) {
+            return new RsData<>("500", "채팅 메시지 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
     }
 
     // 조건에 따른 채팅 메시지 검색 기능
     @GetMapping("/messages/search")
-    public Page<ResponseMessage> searchMessages(@PathVariable("chatRoom-id") Long chatRoomId,
+    public RsData<Page<ResponseMessage>> searchMessages(@PathVariable("chatRoom-id") Long chatRoomId,
                                                 @RequestParam(value = "page", defaultValue = "0") int page,
                                                 @RequestBody MessageSearchKeywordsRequest messageSearchKeywordsRequest) {
-
-        return chatMessageService.searchMessages(chatRoomId, page, messageSearchKeywordsRequest);
+        try {
+            return new RsData<Page<ResponseMessage>>("200", "검색 조건에 따른 채팅 메시지 조회에 성공했습니다.", chatMessageService.searchMessages(chatRoomId, page, messageSearchKeywordsRequest));
+        } catch (Exception e) {
+            return new RsData<>("500", "검색 조건에 따른 채팅 메시지 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
     }
 
 
     // 메시지 읽음/안읽음 상태 확인용 필드 수정
     @PutMapping("/messages/readStatus")
-    public void messageReadStatus(@PathVariable("chatRoom-id") Long chatRoomId,
+    public RsData<Void> messageReadStatus(@PathVariable("chatRoom-id") Long chatRoomId,
                                   @RequestBody MessageReadStatusRequest messageReadStatusRequest) {
-        chatMessageService.messageReadStatus(chatRoomId, messageReadStatusRequest);
+        try {
+            chatMessageService.messageReadStatus(chatRoomId, messageReadStatusRequest);
+            return new RsData<>("200", "메시지 수신 상태 변경 완료");
+        } catch (Exception e) {
+            return new RsData<>("500", "메시지 수신 상태 변경 실패" + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
@@ -1,6 +1,7 @@
 package com.ll.hfback.domain.group.chat.controller;
 
 import com.ll.hfback.domain.group.chat.request.RequestMessage;
+import com.ll.hfback.domain.group.chat.response.MessageReadStatusResponse;
 import com.ll.hfback.domain.group.chat.response.MessageSearchKeywordsResponse;
 import com.ll.hfback.domain.group.chat.response.ResponseMessage;
 import com.ll.hfback.domain.group.chat.service.ChatMessageService;
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/chatRooms/{chatRoom-id}")
 @RequiredArgsConstructor
-public class ChatMessageController {
+public class ApiV1ChatMessageController {
     private final ChatMessageService chatMessageService;
 
     // 채팅 메시지 작성
@@ -48,5 +49,13 @@ public class ChatMessageController {
                                                @RequestBody MessageSearchKeywordsResponse messageSearchKeywordsResponse) {
 
         return chatMessageService.searchMessages(chatRoomId, page, messageSearchKeywordsResponse);
+    }
+
+
+    // 메시지 읽음/안읽음 상태 확인용 필드 수정
+    @PutMapping("/messages/readStatus")
+    public void messageReadStatus(@PathVariable("chatRoom-id") Long chatRoomId,
+                                  @RequestBody MessageReadStatusResponse messageReadStatusResponse) {
+        chatMessageService.messageReadStatus(chatRoomId, messageReadStatusResponse);
     }
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
@@ -1,9 +1,9 @@
 package com.ll.hfback.domain.group.chat.controller;
 
-import com.ll.hfback.domain.group.chat.request.RequestMessage;
-import com.ll.hfback.domain.group.chat.response.MessageReadStatusResponse;
-import com.ll.hfback.domain.group.chat.response.MessageSearchKeywordsResponse;
 import com.ll.hfback.domain.group.chat.response.ResponseMessage;
+import com.ll.hfback.domain.group.chat.request.MessageReadStatusRequest;
+import com.ll.hfback.domain.group.chat.request.MessageSearchKeywordsRequest;
+import com.ll.hfback.domain.group.chat.request.RequestMessage;
 import com.ll.hfback.domain.group.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,33 +29,33 @@ public class ApiV1ChatMessageController {
     // 채팅 메시지 작성
     @PostMapping("/messages")
     public void writeMessage(@PathVariable("chatRoom-id") Long chatRoomId,
-                             @RequestBody ResponseMessage responseMessage) {
+                             @RequestBody RequestMessage requestMessage) {
         chatMessageService.writeMessage(chatRoomId,
-                responseMessage);
+                requestMessage);
     }
 
     // 채팅 메시지 조회
     @GetMapping("/messages")
-    public Page<RequestMessage> readMessages(@PathVariable("chatRoom-id") Long chatRoomId,
-                                             @RequestParam(value = "page", defaultValue = "0") int page) {
+    public Page<ResponseMessage> readMessages(@PathVariable("chatRoom-id") Long chatRoomId,
+                                              @RequestParam(value = "page", defaultValue = "0") int page) {
 
         return chatMessageService.readMessages(chatRoomId, page);
     }
 
     // 조건에 따른 채팅 메시지 검색 기능
     @GetMapping("/messages/search")
-    public Page<RequestMessage> searchMessages(@PathVariable("chatRoom-id") Long chatRoomId,
-                                               @RequestParam(value = "page", defaultValue = "0") int page,
-                                               @RequestBody MessageSearchKeywordsResponse messageSearchKeywordsResponse) {
+    public Page<ResponseMessage> searchMessages(@PathVariable("chatRoom-id") Long chatRoomId,
+                                                @RequestParam(value = "page", defaultValue = "0") int page,
+                                                @RequestBody MessageSearchKeywordsRequest messageSearchKeywordsRequest) {
 
-        return chatMessageService.searchMessages(chatRoomId, page, messageSearchKeywordsResponse);
+        return chatMessageService.searchMessages(chatRoomId, page, messageSearchKeywordsRequest);
     }
 
 
     // 메시지 읽음/안읽음 상태 확인용 필드 수정
     @PutMapping("/messages/readStatus")
     public void messageReadStatus(@PathVariable("chatRoom-id") Long chatRoomId,
-                                  @RequestBody MessageReadStatusResponse messageReadStatusResponse) {
-        chatMessageService.messageReadStatus(chatRoomId, messageReadStatusResponse);
+                                  @RequestBody MessageReadStatusRequest messageReadStatusRequest) {
+        chatMessageService.messageReadStatus(chatRoomId, messageReadStatusRequest);
     }
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/entity/ChatMessage.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/entity/ChatMessage.java
@@ -37,6 +37,6 @@ public class ChatMessage extends BaseEntity {
     @Column(nullable = false)
     private String nickname;
 
-    @Builder.Default
-    private int chatMessageStatus = 1; // 기본값 = 1 (안읽음 상태), 0 (읽음 상태)
+//    @Builder.Default
+//    private int chatMessageStatus = 1; // 기본값 = 1 (안읽음 상태), 0 (읽음 상태)
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/entity/ChatMessage.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/entity/ChatMessage.java
@@ -36,7 +36,4 @@ public class ChatMessage extends BaseEntity {
 
     @Column(nullable = false)
     private String nickname;
-
-//    @Builder.Default
-//    private int chatMessageStatus = 1; // 기본값 = 1 (안읽음 상태), 0 (읽음 상태)
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/entity/MessageReadStatus.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/entity/MessageReadStatus.java
@@ -1,0 +1,44 @@
+package com.ll.hfback.domain.group.chat.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.ll.hfback.domain.group.chatRoom.entity.ChatRoom;
+import com.ll.hfback.domain.member.member.entity.Member;
+import com.ll.hfback.global.jpa.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * packageName    : com.ll.hfback.domain.group.chat.entity
+ * fileName       : MessageReadStatus
+ * author         : sungjun
+ * date           : 2025-01-27
+ * description    : 자동 주석 생성
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2025-01-27        kyd54       최초 생성
+ */
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class MessageReadStatus extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    @JsonIgnore
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    @JsonIgnore
+    private Member member;
+
+    private Long lastReadMessageId;
+}

--- a/src/main/java/com/ll/hfback/domain/group/chat/repository/MessageReadStatusRepository.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/repository/MessageReadStatusRepository.java
@@ -1,0 +1,19 @@
+package com.ll.hfback.domain.group.chat.repository;
+
+import com.ll.hfback.domain.group.chat.entity.MessageReadStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * packageName    : com.ll.hfback.domain.group.chat.repository
+ * fileName       : MessageReadStatusRepository
+ * author         : sungjun
+ * date           : 2025-01-27
+ * description    : 자동 주석 생성
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2025-01-27        kyd54       최초 생성
+ */
+public interface MessageReadStatusRepository extends JpaRepository<MessageReadStatus, Long> {
+
+}

--- a/src/main/java/com/ll/hfback/domain/group/chat/repository/MessageReadStatusRepository.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/repository/MessageReadStatusRepository.java
@@ -3,6 +3,8 @@ package com.ll.hfback.domain.group.chat.repository;
 import com.ll.hfback.domain.group.chat.entity.MessageReadStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 /**
  * packageName    : com.ll.hfback.domain.group.chat.repository
  * fileName       : MessageReadStatusRepository
@@ -15,5 +17,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * 2025-01-27        kyd54       최초 생성
  */
 public interface MessageReadStatusRepository extends JpaRepository<MessageReadStatus, Long> {
-
+    Optional<MessageReadStatus> findByChatRoomIdAndMemberId(Long chatRoomId, Long memberId);
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/request/MessageReadStatusRequest.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/request/MessageReadStatusRequest.java
@@ -1,4 +1,4 @@
-package com.ll.hfback.domain.group.chat.response;
+package com.ll.hfback.domain.group.chat.request;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -16,7 +16,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-public class MessageReadStatusResponse {
+public class MessageReadStatusRequest {
     private Long memberId;
     private Long messageId;
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/request/MessageSearchKeywordsRequest.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/request/MessageSearchKeywordsRequest.java
@@ -1,4 +1,4 @@
-package com.ll.hfback.domain.group.chat.response;
+package com.ll.hfback.domain.group.chat.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,7 +22,7 @@ import java.time.LocalDate;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class MessageSearchKeywordsResponse {
+public class MessageSearchKeywordsRequest {
     private String keyword;
     private String nickname;
     private LocalDate startDate;

--- a/src/main/java/com/ll/hfback/domain/group/chat/request/RequestMessage.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/request/RequestMessage.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 /**
  * packageName    : com.ll.hfback.domain.group.chat.request
  * fileName       : RequestMessage
@@ -22,4 +24,6 @@ public class RequestMessage {
     private String nickname;
     @JsonProperty("chatMessageContent")
     private String content;
+    @JsonProperty("messageTimestamp")
+    private LocalDateTime messageTimestamp;
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/request/RequestMessage.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/request/RequestMessage.java
@@ -1,31 +1,24 @@
 package com.ll.hfback.domain.group.chat.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
-
 /**
- * packageName    : com.ll.hfback.domain.group.chat.request
- * fileName       : RequestMessage
+ * packageName    : com.ll.hfback.domain.group.chat.dto.response
+ * fileName       : ResponseMessage
  * author         : sungjun
- * date           : 2025-01-23
+ * date           : 2025-01-22
  * description    : 자동 주석 생성
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 2025-01-23        kyd54       최초 생성
+ * 2025-01-22        kyd54       최초 생성
  */
+@Getter
 @Setter
 @AllArgsConstructor
 public class RequestMessage {
-    @JsonProperty("nickname")
-    private String nickname;
-    @JsonProperty("chatMessageContent")
+    private Long memberId;
     private String content;
-    @JsonProperty("messageTimestamp")
-    private LocalDateTime messageTimestamp;
-    @JsonProperty("messageId")
-    private Long messageId;
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/request/RequestMessage.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/request/RequestMessage.java
@@ -26,4 +26,6 @@ public class RequestMessage {
     private String content;
     @JsonProperty("messageTimestamp")
     private LocalDateTime messageTimestamp;
+    @JsonProperty("messageId")
+    private Long messageId;
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/response/MessageReadStatusResponse.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/response/MessageReadStatusResponse.java
@@ -1,0 +1,22 @@
+package com.ll.hfback.domain.group.chat.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * packageName    : com.ll.hfback.domain.group.chat.response
+ * fileName       : MessageReadStatusResponse
+ * author         : sungjun
+ * date           : 2025-01-28
+ * description    : 자동 주석 생성
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2025-01-28        kyd54       최초 생성
+ */
+@Getter
+@Setter
+public class MessageReadStatusResponse {
+    private Long memberId;
+    private Long messageId;
+}

--- a/src/main/java/com/ll/hfback/domain/group/chat/response/ResponseMessage.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/response/ResponseMessage.java
@@ -1,24 +1,31 @@
 package com.ll.hfback.domain.group.chat.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 /**
- * packageName    : com.ll.hfback.domain.group.chat.dto.response
- * fileName       : ResponseMessage
+ * packageName    : com.ll.hfback.domain.group.chat.request
+ * fileName       : RequestMessage
  * author         : sungjun
- * date           : 2025-01-22
+ * date           : 2025-01-23
  * description    : 자동 주석 생성
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 2025-01-22        kyd54       최초 생성
+ * 2025-01-23        kyd54       최초 생성
  */
-@Getter
 @Setter
 @AllArgsConstructor
 public class ResponseMessage {
-    private Long memberId;
+    @JsonProperty("nickname")
+    private String nickname;
+    @JsonProperty("chatMessageContent")
     private String content;
+    @JsonProperty("messageTimestamp")
+    private LocalDateTime messageTimestamp;
+    @JsonProperty("messageId")
+    private Long messageId;
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/service/ChatMessageService.java
@@ -1,9 +1,9 @@
 package com.ll.hfback.domain.group.chat.service;
 
-import com.ll.hfback.domain.group.chat.request.RequestMessage;
-import com.ll.hfback.domain.group.chat.response.MessageReadStatusResponse;
-import com.ll.hfback.domain.group.chat.response.MessageSearchKeywordsResponse;
 import com.ll.hfback.domain.group.chat.response.ResponseMessage;
+import com.ll.hfback.domain.group.chat.request.MessageReadStatusRequest;
+import com.ll.hfback.domain.group.chat.request.MessageSearchKeywordsRequest;
+import com.ll.hfback.domain.group.chat.request.RequestMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -20,19 +20,19 @@ import org.springframework.data.domain.Pageable;
  */
 public interface ChatMessageService {
     // 해당 채팅방에 채팅 메시지 저장
-    void writeMessage(Long chatRoomId, ResponseMessage responseMessage);
+    void writeMessage(Long chatRoomId, RequestMessage requestMessage);
 
     // 해당 채팅방의 모든 메시지 불러오기
-    Page<RequestMessage> readMessages(Long chatRoomId, int page);
+    Page<ResponseMessage> readMessages(Long chatRoomId, int page);
 
     // 메시지 불러올 때 사용할 커스텀 페이징
     Pageable customPaging(int page);
 
     // 조건에 따른 채팅 메시지 검색 기능
-    Page<RequestMessage> searchMessages(Long chatRoomId,
-                                        int page,
-                                        MessageSearchKeywordsResponse messageSearchKeywordsResponse);
+    Page<ResponseMessage> searchMessages(Long chatRoomId,
+                                         int page,
+                                         MessageSearchKeywordsRequest messageSearchKeywordsRequest);
     
     // 메시지 읽음/안읽음 상태 확인
-    void messageReadStatus(Long chatRoomId, MessageReadStatusResponse messageReadStatusResponse);
+    void messageReadStatus(Long chatRoomId, MessageReadStatusRequest messageReadStatusRequest);
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/service/ChatMessageService.java
@@ -1,6 +1,7 @@
 package com.ll.hfback.domain.group.chat.service;
 
 import com.ll.hfback.domain.group.chat.request.RequestMessage;
+import com.ll.hfback.domain.group.chat.response.MessageReadStatusResponse;
 import com.ll.hfback.domain.group.chat.response.MessageSearchKeywordsResponse;
 import com.ll.hfback.domain.group.chat.response.ResponseMessage;
 import org.springframework.data.domain.Page;
@@ -31,4 +32,7 @@ public interface ChatMessageService {
     Page<RequestMessage> searchMessages(Long chatRoomId,
                                         int page,
                                         MessageSearchKeywordsResponse messageSearchKeywordsResponse);
+    
+    // 메시지 읽음/안읽음 상태 확인
+    void messageReadStatus(Long chatRoomId, MessageReadStatusResponse messageReadStatusResponse);
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
@@ -98,11 +98,14 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     @Transactional(readOnly = true)
     public Page<RequestMessage> readMessages(Long chatRoomId, int page) {
         try {
-            Page<ChatMessage> chatMessagesPage = chatMessageRepository.findByChatRoomId(chatRoomId, customPaging(page));
+            Page<ChatMessage> chatMessages = chatMessageRepository.findByChatRoomId(chatRoomId, customPaging(page));
             logger.info("채팅 메시지 가져오기 성공");
             // ChatMessage -> RequestMessage 변환
-            return chatMessagesPage.map(chatMessage ->
-                    new RequestMessage(chatMessage.getNickname(), chatMessage.getChatMessageContent()));
+            return chatMessages.map(chatMessage ->
+                    new RequestMessage(chatMessage.getNickname(),
+                            chatMessage.getChatMessageContent(),
+                            chatMessage.getCreateDate()
+                    ));
         } catch (Exception e) {
             logger.info("채팅 메시지 가져오기 실패");
             throw e;
@@ -178,7 +181,9 @@ public class ChatMessageServiceImpl implements ChatMessageService {
             logger.info("조건에 따른 채팅 메시지 검색 성공");
             // ChatMessage -> RequestMessage 변환
             return searchMessages.map(chatMessage ->
-                    new RequestMessage(chatMessage.getNickname(), chatMessage.getChatMessageContent()));
+                    new RequestMessage(chatMessage.getNickname(),
+                            chatMessage.getChatMessageContent(),
+                            chatMessage.getCreateDate()));
         } catch (Exception e) {
             logger.info("조건에 따른 채팅 메시지 검색 실패");
             throw e;

--- a/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
@@ -3,10 +3,10 @@ package com.ll.hfback.domain.group.chat.serviceImpl;
 import com.ll.hfback.domain.group.chat.entity.MessageReadStatus;
 import com.ll.hfback.domain.group.chat.entity.QChatMessage;
 import com.ll.hfback.domain.group.chat.repository.MessageReadStatusRepository;
-import com.ll.hfback.domain.group.chat.request.RequestMessage;
-import com.ll.hfback.domain.group.chat.response.MessageReadStatusResponse;
-import com.ll.hfback.domain.group.chat.response.MessageSearchKeywordsResponse;
 import com.ll.hfback.domain.group.chat.response.ResponseMessage;
+import com.ll.hfback.domain.group.chat.request.MessageReadStatusRequest;
+import com.ll.hfback.domain.group.chat.request.MessageSearchKeywordsRequest;
+import com.ll.hfback.domain.group.chat.request.RequestMessage;
 import com.ll.hfback.domain.group.chat.entity.ChatMessage;
 import com.ll.hfback.domain.group.chat.repository.ChatMessageRepository;
 import com.ll.hfback.domain.group.chat.service.ChatMessageService;
@@ -53,13 +53,13 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
     // 채팅 메시지 작성
     @Transactional
-    public void writeMessage(Long chatId, ResponseMessage responseMessage) {
+    public void writeMessage(Long chatId, RequestMessage requestMessage) {
         try {
             // 빈 메시지 또는 250자 초과 메시지 검사
-            if (responseMessage.getContent() == null || responseMessage.getContent().trim().isEmpty()) {
+            if (requestMessage.getContent() == null || requestMessage.getContent().trim().isEmpty()) {
                 throw new IllegalArgumentException("채팅 메시지는 비어 있을 수 없습니다.");
             }
-            if (responseMessage.getContent().length() > 250) {
+            if (requestMessage.getContent().length() > 250) {
                 throw new IllegalArgumentException("채팅 메시지는 250자를 넘을 수 없습니다.");
             }
 
@@ -68,13 +68,13 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
             if(chatRoom != null) {
                 // memberId로 멤버 정보 가져오기
-                Member member = memberRepository.findById(responseMessage.getMemberId()).orElse(null);
+                Member member = memberRepository.findById(requestMessage.getMemberId()).orElse(null);
 
                 // 채팅 메시지 저장
                 ChatMessage chatMessage = ChatMessage.builder()
                         .chatRoom(chatRoom)
                         .nickname(member.getNickname())
-                        .chatMessageContent(responseMessage.getContent())
+                        .chatMessageContent(requestMessage.getContent())
                         .build();
 
                 chatMessageRepository.save(chatMessage);
@@ -100,13 +100,13 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
     // 채팅 메시지 가져오기
     @Transactional(readOnly = true)
-    public Page<RequestMessage> readMessages(Long chatRoomId, int page) {
+    public Page<ResponseMessage> readMessages(Long chatRoomId, int page) {
         try {
             Page<ChatMessage> chatMessages = chatMessageRepository.findByChatRoomId(chatRoomId, customPaging(page));
             logger.info("채팅 메시지 가져오기 성공");
             // ChatMessage -> RequestMessage 변환
             return chatMessages.map(chatMessage ->
-                    new RequestMessage(chatMessage.getNickname(),
+                    new ResponseMessage(chatMessage.getNickname(),
                             chatMessage.getChatMessageContent(),
                             chatMessage.getCreateDate(),
                             chatMessage.getId()
@@ -133,45 +133,45 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     }
 
     // 조건에 따른 채팅 메시지 검색 기능
-    public Page<RequestMessage> searchMessages(Long chatRoomId,
-                                               int page,
-                                               MessageSearchKeywordsResponse messageSearchKeywordsResponse) {
+    public Page<ResponseMessage> searchMessages(Long chatRoomId,
+                                                int page,
+                                                MessageSearchKeywordsRequest messageSearchKeywordsRequest) {
         try {
             QChatMessage qChatMessage = QChatMessage.chatMessage; // QueryDSL 메타 모델 객체
 
             BooleanBuilder builder = new BooleanBuilder();
 
             // 검색어(keyword)가 있으면 해당 조건 추가
-            if (messageSearchKeywordsResponse != null && messageSearchKeywordsResponse.getKeyword() != null) {
-                String keyword = messageSearchKeywordsResponse.getKeyword();
+            if (messageSearchKeywordsRequest != null && messageSearchKeywordsRequest.getKeyword() != null) {
+                String keyword = messageSearchKeywordsRequest.getKeyword();
                 builder.and(qChatMessage.chatMessageContent.containsIgnoreCase(keyword)); // 대소문자 구분 없이 검색
             }
 
             // 닉네임(nickname)이 있으면 해당 조건 추가
-            if (messageSearchKeywordsResponse.getNickname() != null) {
-                String nickname = messageSearchKeywordsResponse.getNickname();
+            if (messageSearchKeywordsRequest.getNickname() != null) {
+                String nickname = messageSearchKeywordsRequest.getNickname();
                 builder.and(qChatMessage.nickname.containsIgnoreCase(nickname)); // 대소문자 구분 없이 검색
             }
 
             // 날짜 처리: 날짜를 LocalDateTime으로 변환하여 비교
             // startDate만 있을 경우
-            if (messageSearchKeywordsResponse.getStartDate() != null) {
-                LocalDate startDate = messageSearchKeywordsResponse.getStartDate();
+            if (messageSearchKeywordsRequest.getStartDate() != null) {
+                LocalDate startDate = messageSearchKeywordsRequest.getStartDate();
                 LocalDateTime startDateTime = startDate.atStartOfDay(); // startDate를 00:00:00로 변환
                 builder.and(qChatMessage.createDate.goe(startDateTime)); // startDate부터 최근까지 메시지 검색
             }
 
             // endDate만 있을 경우
-            if (messageSearchKeywordsResponse.getEndDate() != null) {
-                LocalDate endDate = messageSearchKeywordsResponse.getEndDate();
+            if (messageSearchKeywordsRequest.getEndDate() != null) {
+                LocalDate endDate = messageSearchKeywordsRequest.getEndDate();
                 LocalDateTime endDateTime = endDate.atTime(23, 59, 59, 999999999); // endDate를 23:59:59로 변환
                 builder.and(qChatMessage.createDate.loe(endDateTime)); // 처음부터 endDate까지 메시지 검색
             }
 
             // startDate와 endDate 모두 있을 경우
-            if (messageSearchKeywordsResponse.getStartDate() != null && messageSearchKeywordsResponse.getEndDate() != null) {
-                LocalDate startDate = messageSearchKeywordsResponse.getStartDate();
-                LocalDate endDate = messageSearchKeywordsResponse.getEndDate();
+            if (messageSearchKeywordsRequest.getStartDate() != null && messageSearchKeywordsRequest.getEndDate() != null) {
+                LocalDate startDate = messageSearchKeywordsRequest.getStartDate();
+                LocalDate endDate = messageSearchKeywordsRequest.getEndDate();
                 LocalDateTime startDateTime = startDate.atStartOfDay(); // startDate를 00:00:00로 변환
                 LocalDateTime endDateTime = endDate.atTime(23, 59, 59, 999999999); // endDate를 23:59:59로 변환
                 builder.and(qChatMessage.createDate.between(startDateTime, endDateTime)); // 두 날짜 사이의 메시지 검색
@@ -186,7 +186,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
             logger.info("조건에 따른 채팅 메시지 검색 성공");
             // ChatMessage -> RequestMessage 변환
             return searchMessages.map(chatMessage ->
-                    new RequestMessage(chatMessage.getNickname(),
+                    new ResponseMessage(chatMessage.getNickname(),
                             chatMessage.getChatMessageContent(),
                             chatMessage.getCreateDate(),
                             chatMessage.getId()));
@@ -198,22 +198,22 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
     // 메시지 읽음/안읽음 상태 확인
     @Transactional
-    public void messageReadStatus(Long chatRoomId, MessageReadStatusResponse messageReadStatusResponse) {
+    public void messageReadStatus(Long chatRoomId, MessageReadStatusRequest messageReadStatusRequest) {
         try {
             MessageReadStatus readStatus = messageReadStatusRepository
-                    .findByChatRoomIdAndMemberId(chatRoomId, messageReadStatusResponse.getMemberId())
+                    .findByChatRoomIdAndMemberId(chatRoomId, messageReadStatusRequest.getMemberId())
                     .orElse(MessageReadStatus.builder()
                             .chatRoom(chatRoomRepository.findById(chatRoomId).orElseThrow(() -> new RuntimeException("ChatRoom not found")))
-                            .member(memberRepository.findById(messageReadStatusResponse.getMemberId()).orElseThrow(() -> new RuntimeException("Member not found")))
-                            .lastReadMessageId(messageReadStatusResponse.getMessageId())
+                            .member(memberRepository.findById(messageReadStatusRequest.getMemberId()).orElseThrow(() -> new RuntimeException("Member not found")))
+                            .lastReadMessageId(messageReadStatusRequest.getMessageId())
                             .build());
 
-            readStatus.setLastReadMessageId(messageReadStatusResponse.getMessageId());
+            readStatus.setLastReadMessageId(messageReadStatusRequest.getMessageId());
             messageReadStatusRepository.save(readStatus);
 
             logger.info("ChatRoom ID: {}, Member ID: {} - 마지막 읽은 메시지 ID가 성공적으로 업데이트되었습니다.",
                     chatRoomId,
-                    messageReadStatusResponse.getMemberId());
+                    messageReadStatusRequest.getMemberId());
         } catch (Exception e) {
             logger.error("마지막 읽은 메시지 업데이트 실패");
             throw e;

--- a/src/main/java/com/ll/hfback/global/initData/NotProd.java
+++ b/src/main/java/com/ll/hfback/global/initData/NotProd.java
@@ -1,12 +1,8 @@
 package com.ll.hfback.global.initData;
 
-import com.ll.hfback.domain.festival.comment.form.AddCommentForm;
-import com.ll.hfback.domain.festival.comment.form.UpdateCommentForm;
 import com.ll.hfback.domain.festival.comment.service.CommentService;
-import com.ll.hfback.domain.group.chat.response.ResponseMessage;
+import com.ll.hfback.domain.group.chat.request.RequestMessage;
 import com.ll.hfback.domain.group.chat.service.ChatMessageService;
-import com.ll.hfback.domain.group.chatRoom.form.CreateChatRoomForm;
-import com.ll.hfback.domain.group.chatRoom.form.UpdateChatRoomForm;
 import com.ll.hfback.domain.group.chatRoom.service.ChatRoomService;
 import com.ll.hfback.domain.member.auth.dto.SignupRequest;
 import com.ll.hfback.domain.member.auth.service.AuthService;
@@ -207,10 +203,10 @@ public class NotProd {
                         default -> member3;
                     };
 
-                    ResponseMessage responseMessage = new ResponseMessage(sender.getId(), messages.get(i));
+                    RequestMessage requestMessage = new RequestMessage(sender.getId(), messages.get(i));
 
                     // 메시지 저장 호출
-                    chatMessageService.writeMessage(1L, responseMessage
+                    chatMessageService.writeMessage(1L, requestMessage
                     );
                 }
 


### PR DESCRIPTION
## 개발 내용
- 채팅 수신 확인 테이블을 새로 생성, 멤버 별 마지막으로 확인한 메시지 ID를 컬럼에 저장하여 이를 기준으로 메시지 상태를 처리함