### PR TITLE
feat: 채팅방에서 채팅방 멤버가 읽지 않은 메시지의 수 출력 기능 추가

### DIFF
--- a/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
@@ -58,9 +58,10 @@ public class ApiV1ChatMessageController {
 
     // 채팅 메시지 읽음 카운트
     @GetMapping("/messages/count")
-    public RsData<List<ResponseMessageCount>> messageCount(@PathVariable("chatRoom-id") Long chatRoomId) {
+    public RsData<List<ResponseMessageCount>> messageCount(@PathVariable("chatRoom-id") Long chatRoomId,
+                                                    @LoginUser Member loginUser) {
         try {
-            return new RsData<>("200", "메시지 카운트 불러오기 성공", chatMessageService.messageCount(chatRoomId));
+            return new RsData<>("200", "메시지 카운트 불러오기 성공", chatMessageService.messageCount(chatRoomId, loginUser));
         } catch (Exception e) {
             return new RsData<>("500", "메시지 카운트 불러오기 실패: " + e.getMessage());
         }
@@ -104,9 +105,9 @@ public class ApiV1ChatMessageController {
     // 채팅방 멤버 로그인 상태 변경 (로그아웃)
     @PatchMapping("/members/logout")
     public RsData<Void> chatMemberLogout(@PathVariable("chatRoom-id") Long chatRoomId,
-                                         @LoginUser Member member) {
+                                         @LoginUser Member loginUser) {
         try {
-            chatMessageService.chatMemberLogout(chatRoomId, member);
+            chatMessageService.chatMemberLogout(chatRoomId, loginUser);
             return new RsData<Void>("200", "채팅방 멤버 로그아웃 처리 성공");
         } catch (Exception e) {
             return new RsData<Void>("500", "채팅방 멤버 로그아웃 처리 실패" + e);
@@ -116,9 +117,9 @@ public class ApiV1ChatMessageController {
     // 채팅방 멤버 로그인 상태 변경 (로그인)
     @PatchMapping("/members/login")
     public RsData<Void> chatMemberLogin(@PathVariable("chatRoom-id") Long chatRoomId,
-                                         @LoginUser Member member) {
+                                         @LoginUser Member loginUser) {
         try {
-            chatMessageService.chatMemberLogin(chatRoomId, member);
+            chatMessageService.chatMemberLogin(chatRoomId, loginUser);
             return new RsData<Void>("200", "채팅방 멤버 로그인 처리 성공");
         } catch (Exception e) {
             return new RsData<Void>("500", "채팅방 멤버 로그인 처리 실패" + e);

--- a/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/controller/ApiV1ChatMessageController.java
@@ -5,6 +5,7 @@ import com.ll.hfback.domain.group.chat.response.ResponseMessage;
 import com.ll.hfback.domain.group.chat.request.MessageReadStatusRequest;
 import com.ll.hfback.domain.group.chat.request.MessageSearchKeywordsRequest;
 import com.ll.hfback.domain.group.chat.request.RequestMessage;
+import com.ll.hfback.domain.group.chat.response.ResponseMessageCount;
 import com.ll.hfback.domain.group.chat.service.ChatMessageService;
 import com.ll.hfback.domain.member.member.entity.Member;
 import com.ll.hfback.global.rsData.RsData;
@@ -37,8 +38,7 @@ public class ApiV1ChatMessageController {
     public RsData<Object> writeMessage(@PathVariable("chatRoom-id") Long chatRoomId,
                                        @RequestBody RequestMessage requestMessage, @LoginUser Member loginUser) {
         try {
-            RsData<Object> response = chatMessageService.writeMessage(chatRoomId, requestMessage, loginUser);
-            return response; // ✅ 서비스에서 반환한 응답을 그대로 반환
+            return chatMessageService.writeMessage(chatRoomId, requestMessage, loginUser); // ✅ 서비스에서 반환한 응답을 그대로 반환
         } catch (Exception e) {
             return new RsData<>("500", "채팅 메시지 작성 중 오류가 발생했습니다: " + e.getMessage());
         }
@@ -53,6 +53,16 @@ public class ApiV1ChatMessageController {
             return new RsData<>("200", "채팅 메시지 조회 성공", messages);
         } catch (Exception e) {
             return new RsData<>("500", "채팅 메시지 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // 채팅 메시지 읽음 카운트
+    @GetMapping("/messages/count")
+    public RsData<List<ResponseMessageCount>> messageCount(@PathVariable("chatRoom-id") Long chatRoomId) {
+        try {
+            return new RsData<>("200", "메시지 카운트 불러오기 성공", chatMessageService.messageCount(chatRoomId));
+        } catch (Exception e) {
+            return new RsData<>("500", "메시지 카운트 불러오기 실패: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/ll/hfback/domain/group/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/repository/ChatMessageRepository.java
@@ -1,10 +1,15 @@
 package com.ll.hfback.domain.group.chat.repository;
 
 import com.ll.hfback.domain.group.chat.entity.ChatMessage;
+import com.ll.hfback.domain.group.chat.response.ResponseMessageCount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 /**
  * packageName    : com.ll.hfback.domain.group.chat.repository
@@ -19,4 +24,15 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
  */
 public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long>, QuerydslPredicateExecutor<ChatMessage> {
     Page<ChatMessage> findByChatRoomId(Long chatRoomId, Pageable pageable);
+
+    @Query("""
+    SELECT new com.ll.hfback.domain.group.chat.response.ResponseMessageCount(m.id, COUNT(cru.member.id))
+    FROM ChatMessage m
+    LEFT JOIN ChatRoomUser cru
+    ON m.chatRoom.id = cru.chatRoom.id
+    AND m.id > cru.lastReadMessageId
+    WHERE m.chatRoom.id = :chatRoomId
+    GROUP BY m.id
+""")
+    List<ResponseMessageCount> getUnreadMessageCount(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/ll/hfback/domain/group/chat/response/ResponseMessageCount.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/response/ResponseMessageCount.java
@@ -1,0 +1,28 @@
+package com.ll.hfback.domain.group.chat.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * packageName    : com.ll.hfback.domain.group.chat.response
+ * fileName       : ResponseMessageCount
+ * author         : sungjun
+ * date           : 2025-02-06
+ * description    : 자동 주석 생성
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2025-02-06        kyd54       최초 생성
+ */
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseMessageCount {
+    @JsonProperty("messageId")
+    private Long messageId;
+
+    @JsonProperty("count")
+    private Long count;
+}

--- a/src/main/java/com/ll/hfback/domain/group/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/service/ChatMessageService.java
@@ -33,7 +33,7 @@ public interface ChatMessageService {
     Page<ResponseMessage> readMessages(Long chatRoomId, int page, Member loginUser);
 
     // 채팅 메시지 읽음 카운트
-    List<ResponseMessageCount> messageCount(Long chatRoomId);
+    List<ResponseMessageCount> messageCount(Long chatRoomId, Member loginUser);
 
     // 메시지 불러올 때 사용할 커스텀 페이징
     Pageable customPaging(int page);
@@ -50,10 +50,10 @@ public interface ChatMessageService {
     List<ResponseMemberStatus> memberLoginStatus(Long chatRoomId, Member loginUser);
 
     // 멤버 채팅방 접속 상태 변경 (온라인)
-    void chatMemberLogin(Long chatRoomId, Member member);
+    void chatMemberLogin(Long chatRoomId, Member loginUser);
 
     // 멤버 채팅방 접속 상태 변경 (오프라인)
-    void chatMemberLogout(Long chatRoomId, Member member);
+    void chatMemberLogout(Long chatRoomId, Member loginUser);
 
     // 로그아웃시 전체 채팅방에서 오프라인 처리
     void allChatLogout(Map<String, Long> body);

--- a/src/main/java/com/ll/hfback/domain/group/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/service/ChatMessageService.java
@@ -5,6 +5,7 @@ import com.ll.hfback.domain.group.chat.response.ResponseMessage;
 import com.ll.hfback.domain.group.chat.request.MessageReadStatusRequest;
 import com.ll.hfback.domain.group.chat.request.MessageSearchKeywordsRequest;
 import com.ll.hfback.domain.group.chat.request.RequestMessage;
+import com.ll.hfback.domain.group.chat.response.ResponseMessageCount;
 import com.ll.hfback.domain.member.member.entity.Member;
 import com.ll.hfback.global.rsData.RsData;
 import org.springframework.data.domain.Page;
@@ -30,6 +31,9 @@ public interface ChatMessageService {
 
     // 해당 채팅방의 모든 메시지 불러오기
     Page<ResponseMessage> readMessages(Long chatRoomId, int page, Member loginUser);
+
+    // 채팅 메시지 읽음 카운트
+    List<ResponseMessageCount> messageCount(Long chatRoomId);
 
     // 메시지 불러올 때 사용할 커스텀 페이징
     Pageable customPaging(int page);

--- a/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
@@ -88,7 +88,11 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                     .chatMessageContent(requestMessage.getContent())
                     .build();
             chatMessageRepository.save(chatMessage);
-            simpMessagingTemplate.convertAndSend("/topic/chat/" + chatRoomId, chatMessage);
+            simpMessagingTemplate.convertAndSend("/topic/chat/" + chatRoomId,
+                    Map.of(
+                            "type", "MESSAGE",
+                            "data", chatMessage
+                    ));
 
             logger.info("채팅 메시지 작성 성공");
             return new RsData<>("200", "채팅 메시지 작성 성공");
@@ -130,8 +134,14 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     // 채팅 메시지 읽음 카운트
     public List<ResponseMessageCount> messageCount(Long chatRoomId) {
         try {
+            List<ResponseMessageCount> unreadMessageCount = chatMessageRepository.getUnreadMessageCount(chatRoomId);
             logger.info("채팅 메시지 읽음 카운트 성공");
-            return chatMessageRepository.getUnreadMessageCount(chatRoomId);
+            simpMessagingTemplate.convertAndSend("/topic/chat/" + chatRoomId,
+                    Map.of(
+                            "type", "COUNT",
+                            "data", unreadMessageCount
+                    ));
+            return unreadMessageCount;
         } catch (Exception e) {
             logger.error("채팅 메시지 읽음 카운트 실패");
             throw new RuntimeException(e);

--- a/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
@@ -272,9 +272,6 @@ public class ChatMessageServiceImpl implements ChatMessageService {
             readStatus.setLastReadMessageId(messageReadStatusRequest.getMessageId());
             chatRoomUserRepository.save(readStatus);
 
-            // 마지막으로 읽은 메시지ID 저장과 동시에 채팅 메시지 카운트
-            messageCount(chatRoomId, loginUser);
-
             logger.info("ChatRoom ID: {}, Member ID: {} - 마지막 읽은 메시지 ID가 성공적으로 업데이트되었습니다.",
                     chatRoomId,
                     loginUser.getId());

--- a/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
@@ -11,6 +11,7 @@ import com.ll.hfback.domain.group.chat.request.MessageSearchKeywordsRequest;
 import com.ll.hfback.domain.group.chat.request.RequestMessage;
 import com.ll.hfback.domain.group.chat.entity.ChatMessage;
 import com.ll.hfback.domain.group.chat.repository.ChatMessageRepository;
+import com.ll.hfback.domain.group.chat.response.ResponseMessageCount;
 import com.ll.hfback.domain.group.chat.service.ChatMessageService;
 import com.ll.hfback.domain.group.chatRoom.entity.ChatRoom;
 import com.ll.hfback.domain.group.chatRoom.repository.ChatRoomRepository;
@@ -29,8 +30,6 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -123,8 +122,19 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                             chatMessage.getId()
                     ));
         } catch (Exception e) {
-            logger.info("채팅 메시지 가져오기 실패");
-            throw e;
+            logger.error("채팅 메시지 가져오기 실패");
+            throw new RuntimeException(e);
+        }
+    }
+
+    // 채팅 메시지 읽음 카운트
+    public List<ResponseMessageCount> messageCount(Long chatRoomId) {
+        try {
+            logger.info("채팅 메시지 읽음 카운트 성공");
+            return chatMessageRepository.getUnreadMessageCount(chatRoomId);
+        } catch (Exception e) {
+            logger.error("채팅 메시지 읽음 카운트 실패");
+            throw new RuntimeException(e);
         }
     }
 
@@ -138,8 +148,8 @@ public class ChatMessageServiceImpl implements ChatMessageService {
             // 페이지 번호와 크기, 정렬을 포함하여 Pageable 객체 생성
             return PageRequest.of(page, 10, sort);
         } catch (Exception e) {
-            logger.info("커스텀 페이징 실패");
-            throw e;
+            logger.error("커스텀 페이징 실패");
+            throw new RuntimeException(e);
         }
     }
 
@@ -212,8 +222,8 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                             chatMessage.getCreateDate(),
                             chatMessage.getId()));
         } catch (Exception e) {
-            logger.info("조건에 따른 채팅 메시지 검색 실패");
-            throw e;
+            logger.error("조건에 따른 채팅 메시지 검색 실패");
+            throw new RuntimeException(e);
         }
     }
 
@@ -247,7 +257,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                     loginUser.getId());
         } catch (Exception e) {
             logger.error("마지막 읽은 메시지 업데이트 실패");
-            throw e;
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/ll/hfback/domain/group/chat/serviceImpl/ChatMessageServiceImpl.java
@@ -247,7 +247,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         }
     }
 
-    // 메시지 읽음/안읽음 상태 확인
+    // 채팅방에서 마지막으로 읽은 메시지 ID 갱신
     @Transactional
     public void messageReadStatus(Long chatRoomId, MessageReadStatusRequest messageReadStatusRequest, Member loginUser) {
         try {
@@ -271,6 +271,9 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
             readStatus.setLastReadMessageId(messageReadStatusRequest.getMessageId());
             chatRoomUserRepository.save(readStatus);
+
+            // 마지막으로 읽은 메시지ID 저장과 동시에 채팅 메시지 카운트
+            messageCount(chatRoomId, loginUser);
 
             logger.info("ChatRoom ID: {}, Member ID: {} - 마지막 읽은 메시지 ID가 성공적으로 업데이트되었습니다.",
                     chatRoomId,


### PR DESCRIPTION
## 수정이 필요한 사항 (완료)
- ~~채팅방에 참여할 때 lead_last_message_id 값을 제일 최신 메시지의 id값으로 입력해야함~~
~~(디폴트값 : -1) > 채팅방 처음 입장 시 lead_last_message_id값이 -1이기 때문에~~
~~읽지 않은 메시지 표시 할 시 논리적 에러 발생~~
